### PR TITLE
improve `Result` type tests

### DIFF
--- a/src/result.test.ts
+++ b/src/result.test.ts
@@ -219,17 +219,15 @@ describe("Result", () => {
 	describe("Result.wrap", () => {
 		it("sets the correct types", () => {
 			const wrappedSum = Result.wrap((a: number, b: number) => a + b);
-			expectTypeOf(wrappedSum).parameters.toEqualTypeOf<[number, number]>();
-			expectTypeOf(wrappedSum).returns.toEqualTypeOf<Result<number, Error>>();
+			expectTypeOf(wrappedSum).toEqualTypeOf<
+				(a: number, b: number) => Result<number, Error>
+			>();
 
 			const asyncWrappedSum = Result.wrap(
 				async (a: number, b: number) => a + b,
 			);
-			expectTypeOf(asyncWrappedSum).parameters.toEqualTypeOf<
-				[number, number]
-			>();
-			expectTypeOf(asyncWrappedSum).returns.toEqualTypeOf<
-				AsyncResult<number, Error>
+			expectTypeOf(asyncWrappedSum).toEqualTypeOf<
+				(a: number, b: number) => AsyncResult<number, Error>
 			>();
 		});
 


### PR DESCRIPTION
Just wanted to draw your attention that using `.parameters` and `.returns` in type test do not capture the whole type of a function.

If a function would have properties, these would be missed ([playground](https://www.typescriptlang.org/play/?#code/JYWwDg9gTgLgBAbzgUwB5mQYxgFQJ4YDyAZnAL5zFQQhwBEaG2AtDAcnQNwBQ3wAdjGRRiAQ0zI4ACWQAbWRETc4cABSiAXHH4BXEACNhAGjj6tug8ICUWgM4woAgOY8VAd2iyAJlqSbteoZQnKbmgcLkPGS8APQxcDAAFpIA5AB0HlDeKXBg1BiweHDAtnAgJbbIXnDJUMjcjFi47CQAPDLyEAB8qlZpYKJQoiDIQlC2aTAQAKIAjjqisvhExK0A2hZBJpvCALo9VjyN2MvIbR0KB2l1MDpQ-BNTcwtLLav2jvxOBzzccaY6eD8CBuYrwEpwTCiHRORIwBroJqnc5yS69SYzeaLZGrdRhSxQExmAIEqxwAC8XTgH2cPyAA)):

```ts
import { expectTypeOf } from "expect-type";

interface Hello {
  (a: number, b: number): string;
  world: { a: number; b: number };
}

// the '.world' property is missed here
expectTypeOf<Hello>().parameters.toEqualTypeOf<[number, number]>();
expectTypeOf<Hello>().returns.toEqualTypeOf<string>();

// but now it is caught
expectTypeOf<Hello>().toEqualTypeOf<(a: number, b: number) => string>();
```

Of course, it might be I misunderstood the intention of these tests.