### PR TITLE
catch exceptions thrown inside transform functions

### DIFF
--- a/src/result.test.ts
+++ b/src/result.test.ts
@@ -214,6 +214,19 @@ describe("Result", () => {
 			expect(result.error).toBeInstanceOf(CustomError);
 		});
 
+		it("throws when exceptions are encountered in the transform function", async () => {
+			await expect(() =>
+				Result.try(
+					async (): Promise<number> => {
+						throw new CustomError();
+					},
+					(error) => {
+						throw error;
+					},
+				),
+			).rejects.toThrow(CustomError);
+		});
+
 		it("flattens another result-type when returned by the provided callback", () => {
 			const resultA = Result.try(() => Result.ok("some value"));
 			const resultB = Result.try(() => Result.error(new CustomError()));
@@ -927,6 +940,19 @@ describe("Result", () => {
 			Result.assertError(result);
 
 			expect(result.error).toBeInstanceOf(ErrorA);
+		});
+
+		it("throws when exceptions are encountered in the transform function", async () => {
+			await expect(() =>
+				Result.fromAsyncCatching(
+					async (): Promise<number> => {
+						throw new CustomError();
+					},
+					(error) => {
+						throw error;
+					},
+				),
+			).rejects.toThrow(CustomError);
 		});
 	});
 

--- a/src/result.ts
+++ b/src/result.ts
@@ -757,7 +757,7 @@ export class AsyncResult<Value, Err> extends Promise<OuterResult<Value, Err>> {
 		promise: AnyPromise,
 		transform?: (error: unknown) => unknown,
 	) {
-		return new AsyncResult((resolve) => {
+		return new AsyncResult((resolve, reject) => {
 			promise
 				.then((value) =>
 					resolve(
@@ -766,7 +766,8 @@ export class AsyncResult<Value, Err> extends Promise<OuterResult<Value, Err>> {
 				)
 				.catch((caughtError) => {
 					resolve(ResultFactory.error(transform?.(caughtError) ?? caughtError));
-				});
+				})
+				.catch(reject);
 		});
 	}
 }


### PR DESCRIPTION
transform functions in Result.try and Result.fromAsyncCatching may throw exceptions
-> unhandled rejections
-> application crashes

https://github.com/everweij/typescript-result/pull/8/files#r1741155043